### PR TITLE
fixed bug with add plant btn

### DIFF
--- a/src/components/PlantList.js
+++ b/src/components/PlantList.js
@@ -1,40 +1,39 @@
-import Card from './Card'
-import React, { useEffect }  from "react";
-import { Link } from 'react-router-dom';
-import { connect } from 'react-redux';
-import { fetchPlants } from '../actions/index';
-import '../index.css';
+import Card from "./Card";
+import React, { useEffect } from "react";
+import { Link, useHistory } from "react-router-dom";
+import { connect } from "react-redux";
+import { fetchPlants } from "../actions/index";
+import "../index.css";
 
 const PlantList = (props) => {
+  const plants = props.plants;
+  const history = useHistory();
+  const pathname = history.location.pathname;
 
-    const plants = props.plants;
+  useEffect(() => {
+    props.dispatch(fetchPlants());
+  }, []);
 
-    useEffect(() => {
-       props.dispatch(fetchPlants());
-    }, []);
-  
-
-    return (
-        <div class="container">
-            <div class="add-section">
-                <Link  to="plantlist/add"> 
-                    Add Plant
-                </Link>
-            </div>
-            <div class="card-section">
-                {
-                plants.map(plant=><Card key={plant.id} plant={plant} />)
-                }
-            </div>
-
-        </div>
-    )
-}
+  return (
+    <div class="container">
+      <div class="add-section">
+        <Link to={pathname == "/plantlist" ? "plantlist/add" : "/plantlist"}>
+          <button>Add Plant</button>
+        </Link>
+      </div>
+      <div class="card-section">
+        {plants.map((plant) => (
+          <Card key={plant.id} plant={plant} />
+        ))}
+      </div>
+    </div>
+  );
+};
 
 const mapStateToProps = (state) => {
-    return {
-      plants: state.plants
-    }
-}
-  
+  return {
+    plants: state.plants,
+  };
+};
+
 export default connect(mapStateToProps)(PlantList);


### PR DESCRIPTION
Previously, hitting the add plant btn repeatedly would result in a URL like "./plantlist/add/add/add/add" . After this change, hitting this button repeatedly toggles between "/plantlist" and "/plantlist/add"